### PR TITLE
Adding unique id to new posts

### DIFF
--- a/03_lesson/src/features/posts/postsSlice.js
+++ b/03_lesson/src/features/posts/postsSlice.js
@@ -84,6 +84,7 @@ const postsSlice = createSlice({
                 state.error = action.error.message
             })
             .addCase(addNewPost.fulfilled, (state, action) => {
+                action.payload.id = nanoid();
                 action.payload.userId = Number(action.payload.userId)
                 action.payload.date = new Date().toISOString();
                 action.payload.reactions = {


### PR DESCRIPTION
After creating two or more new posts, same key error appears as new posts will be with the same Id.. Added one line to add unique id to each new post.