### PR TITLE
Replace `PUT`  with `PATCH`

### DIFF
--- a/07_lesson/src/features/posts/postsSlice.js
+++ b/07_lesson/src/features/posts/postsSlice.js
@@ -80,7 +80,7 @@ export const extendedApiSlice = apiSlice.injectEndpoints({
         updatePost: builder.mutation({
             query: initialPost => ({
                 url: `/posts/${initialPost.id}`,
-                method: 'PUT',
+                method: 'PATCH',
                 body: {
                     ...initialPost,
                     date: new Date().toISOString()


### PR DESCRIPTION
After adding some reactions, everything works fine, after editing the `POST`, for instance, change the content, the reaction would be deleted since `PUT `replace the whole object, replaced with `PATCH`