### PR TITLE
delete item issue is solved: remove body from delete query

### DIFF
--- a/06_lesson/package-lock.json
+++ b/06_lesson/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rtk-prep6",
+  "name": "rtk-query-intro",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "rtk-prep6",
+      "name": "rtk-query-intro",
       "version": "0.1.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.1.1",

--- a/06_lesson/src/features/api/apiSlice.js
+++ b/06_lesson/src/features/api/apiSlice.js
@@ -30,7 +30,6 @@ export const apiSlice = createApi({
             query: ({ id }) => ({
                 url: `/todos/${id}`,
                 method: 'DELETE',
-                body: id
             }),
             invalidatesTags: ['Todos']
         }),


### PR DESCRIPTION
## Fix: Remove `body` from DELETE request in `deleteTodo` mutation

### Problem

The previous implementation of the `deleteTodo` mutation included a `body` in the DELETE request:

```js
deleteTodo: builder.mutation({
  query: ({ id }) => ({
    url: `/todos/${id}`,
    method: 'DELETE',
    body: id
  }),
  invalidatesTags: ['Todos']
}),
```

Including a `body` in a DELETE request caused the API to fail to delete items from the todo list. As a result, the delete operation did not work as expected.  
A video demonstrating this issue is attached.

### Solution

This PR removes the unnecessary `body` property from the DELETE request:

```js
deleteTodo: builder.mutation({
  query: ({ id }) => ({
    url: `/todos/${id}`,
    method: 'DELETE',
  }),
  invalidatesTags: ['Todos']
}),
```

### Impact

- The delete operation now works correctly, and todos can be deleted as expected.
- No breaking changes to other endpoints.

### Additional Info

- Video attached showing the issue before this fix.


https://github.com/user-attachments/assets/13a862a1-6439-4fc2-8b50-43c34051c37e


---

**Tested:** Manually tested delete functionality after the change.
